### PR TITLE
feat: Services UI, registry deploy button, webhook containerConfig fix

### DIFF
--- a/backend/internal/api/webhook_handlers.go
+++ b/backend/internal/api/webhook_handlers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -333,8 +334,23 @@ func (h *Handler) createDeploymentFromWebhook(ctx context.Context, config *webho
 		imageDigest = *metadata.ImageDigest
 	}
 
-	// Start deployment pipeline in background (scan → SBOM → policy → deploy)
-	go h.runDeploymentPipeline(context.Background(), orgID, deployment.ID, metadata.ImageRepo, metadata.ImageTag, imageDigest, nil, false)
+	// Load container config from service_config if one exists for this service+env
+	var containerConfig *DeploymentContainerConfig
+	var cfgJSON []byte
+	if err := h.db.QueryRow(ctx, `
+		SELECT container_config FROM service_configs
+		WHERE org_id = $1 AND agent_id = $2 AND service_name = $3 AND environment = $4
+	`, orgID, agentID, config.ServiceName, config.Environment).Scan(&cfgJSON); err == nil {
+		if len(cfgJSON) > 0 {
+			var cfg DeploymentContainerConfig
+			if json.Unmarshal(cfgJSON, &cfg) == nil {
+				containerConfig = &cfg
+			}
+		}
+	}
+
+	// Start deployment pipeline in background
+	go h.runDeploymentPipeline(context.Background(), orgID, deployment.ID, metadata.ImageRepo, metadata.ImageTag, imageDigest, containerConfig, false)
 
 	return deployment.ID, nil
 }

--- a/frontend/app/(dashboard)/docker/layout.tsx
+++ b/frontend/app/(dashboard)/docker/layout.tsx
@@ -42,6 +42,7 @@ const tabGroups: { id: string; label: string; tabs: Tab[] }[] = [
     id: "management",
     label: "Management",
     tabs: [
+      { id: "services",    label: "Services",    href: "/docker/services" },
       { id: "stacks",      label: "Stacks",      href: "/docker/stacks" },
       { id: "deployments", label: "Deployments", href: "/docker/deployments" },
     ],
@@ -103,6 +104,16 @@ function DockerLayoutContent({ children }: { children: ReactNode }) {
   // Get action button based on active tab
   const getActionButton = () => {
     switch (activeTab) {
+      case "services":
+        return (
+          <button
+            onClick={() => setShowDeployWizard(true)}
+            className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors text-sm font-medium"
+          >
+            <Rocket className="w-4 h-4" />
+            Deploy Service
+          </button>
+        );
       case "stacks":
         return (
           <button

--- a/frontend/app/(dashboard)/docker/registries/page.tsx
+++ b/frontend/app/(dashboard)/docker/registries/page.tsx
@@ -54,6 +54,10 @@ export default function DockerRegistriesPage() {
   const [selectedRegistry, setSelectedRegistry] = useState<ContainerRegistry | null>(null);
   const [selectedRepo, setSelectedRepo] = useState<string | null>(null);
   const [copiedImage, setCopiedImage] = useState<string | null>(null);
+  const [deployTarget, setDeployTarget] = useState<{ imageRef: string; repo: string; tag: string } | null>(null);
+  const [deployServiceName, setDeployServiceName] = useState("");
+  const [deployEnv, setDeployEnv] = useState<"dev" | "staging" | "prod">("dev");
+  const [deployResult, setDeployResult] = useState<string | null>(null);
   const [formData, setFormData] = useState({
     name: "",
     provider: "ghcr" as RegistryProvider,
@@ -175,6 +179,19 @@ export default function DockerRegistriesPage() {
     mutationFn: (id: string) => api.testRegistryConnection(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["registries"] });
+    },
+  });
+
+  const deployFromRegistryMutation = useMutation({
+    mutationFn: () => {
+      if (!deployTarget || !deployServiceName.trim() || !selectedAgent) throw new Error("Missing required fields");
+      // Derive tag from imageRef (last part after colon)
+      const tag = deployTarget.tag;
+      return api.deployService(deployServiceName.trim(), deployEnv, { image_tag: tag });
+    },
+    onSuccess: (data) => {
+      setDeployResult(data.message ?? "Deployment started");
+      queryClient.invalidateQueries({ queryKey: ["services"] });
     },
   });
 
@@ -450,6 +467,21 @@ export default function DockerRegistriesPage() {
                           >
                             {copiedImage === imageRef ? <CheckCircle className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
                           </button>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              if (selectedRegistry && selectedRepo) {
+                                setDeployTarget({ imageRef, repo: selectedRepo, tag: tag.name });
+                                setDeployServiceName(selectedRepo.split("/").pop() ?? selectedRepo);
+                                setDeployResult(null);
+                                deployFromRegistryMutation.reset();
+                              }
+                            }}
+                            className="p-2 text-gray-400 hover:text-primary-600 dark:hover:text-primary-400"
+                            title="Deploy this image"
+                          >
+                            <Rocket className="h-4 w-4" />
+                          </button>
                         </div>
                       </div>
                     );
@@ -575,6 +607,97 @@ export default function DockerRegistriesPage() {
                 </div>
               )}
             </form>
+          </div>
+        </div>
+      )}
+      {/* Deploy from Registry Modal */}
+      {deployTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/50" onClick={() => { if (!deployFromRegistryMutation.isPending) { setDeployTarget(null); setDeployResult(null); deployFromRegistryMutation.reset(); } }} />
+          <div className="relative bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-md mx-4 p-6">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="p-2 bg-primary-100 dark:bg-primary-900/30 rounded-lg">
+                <Rocket className="h-5 w-5 text-primary-600 dark:text-primary-400" />
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Deploy Image</h3>
+                <p className="text-xs font-mono text-gray-500 dark:text-gray-400 truncate max-w-[280px]">{deployTarget.imageRef}</p>
+              </div>
+            </div>
+
+            {deployResult ? (
+              <div className="text-center py-4">
+                <CheckCircle className="h-10 w-10 text-green-500 mx-auto mb-3" />
+                <p className="font-medium text-gray-900 dark:text-white mb-1">Deployment started</p>
+                <p className="text-sm text-gray-500 dark:text-gray-400">{deployResult}</p>
+                <button
+                  onClick={() => { setDeployTarget(null); setDeployResult(null); deployFromRegistryMutation.reset(); }}
+                  className="mt-5 px-4 py-2 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg text-sm font-medium"
+                >
+                  Close
+                </button>
+              </div>
+            ) : (
+              <>
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Service Name</label>
+                    <input
+                      type="text"
+                      value={deployServiceName}
+                      onChange={(e) => setDeployServiceName(e.target.value)}
+                      placeholder="e.g. my-app"
+                      className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                    />
+                    <p className="text-xs text-gray-400 mt-1">Creates or updates the service definition</p>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Environment</label>
+                    <div className="flex gap-2">
+                      {(["dev", "staging", "prod"] as const).map((env) => (
+                        <button
+                          key={env}
+                          type="button"
+                          onClick={() => setDeployEnv(env)}
+                          className={cn(
+                            "flex-1 py-2 text-sm font-medium rounded-lg border transition-colors",
+                            deployEnv === env
+                              ? "bg-primary-600 border-primary-600 text-white"
+                              : "bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:border-primary-400"
+                          )}
+                        >
+                          {env}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                  {deployFromRegistryMutation.isError && (
+                    <p className="text-sm text-red-600 dark:text-red-400">
+                      {(deployFromRegistryMutation.error as Error)?.message ?? "Deploy failed"}
+                    </p>
+                  )}
+                </div>
+                <div className="flex justify-end gap-3 mt-6">
+                  <button
+                    onClick={() => { setDeployTarget(null); setDeployResult(null); deployFromRegistryMutation.reset(); }}
+                    className="px-4 py-2 text-sm bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg font-medium"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={() => deployFromRegistryMutation.mutate()}
+                    disabled={deployFromRegistryMutation.isPending || !deployServiceName.trim() || !selectedAgent}
+                    className="inline-flex items-center gap-2 px-4 py-2 text-sm bg-primary-600 hover:bg-primary-700 text-white rounded-lg font-medium disabled:opacity-50"
+                  >
+                    {deployFromRegistryMutation.isPending ? (
+                      <><RefreshCw className="h-4 w-4 animate-spin" />Deploying...</>
+                    ) : (
+                      <><Rocket className="h-4 w-4" />Deploy</>
+                    )}
+                  </button>
+                </div>
+              </>
+            )}
           </div>
         </div>
       )}

--- a/frontend/app/(dashboard)/docker/services/page.tsx
+++ b/frontend/app/(dashboard)/docker/services/page.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Rocket,
+  Trash2,
+  RefreshCw,
+  Box,
+  CheckCircle,
+  XCircle,
+  Clock,
+  Search,
+  MoreHorizontal,
+  GitBranch,
+  Tag,
+} from "lucide-react";
+import { api, ServiceConfig } from "@/lib/api";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Spinner } from "@/components/ui/Spinner";
+import { StatCard, MetricsGrid } from "@/components/ui/StatCard";
+import { cn } from "@/lib/utils";
+
+function statusBadge(status?: string) {
+  const colorMap: Record<string, string> = {
+    running:   "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+    failed:    "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+    deploying: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
+    pending:   "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
+    stopped:   "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
+  };
+  const cls = colorMap[status ?? ""] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400";
+  return <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${cls}`}>{status ?? "unknown"}</span>;
+}
+
+function relativeTime(ts?: string | null): string {
+  if (!ts) return "—";
+  const diff = Date.now() - new Date(ts).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+export default function ServicesPage() {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState("");
+  const [envFilter, setEnvFilter] = useState<"all" | "dev" | "staging" | "prod">("all");
+  const [redeployTarget, setRedeployTarget] = useState<ServiceConfig | null>(null);
+  const [redeployTag, setRedeployTag] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<ServiceConfig | null>(null);
+  const [openMenu, setOpenMenu] = useState<string | null>(null);
+
+  const { data: services, isLoading } = useQuery({
+    queryKey: ["services"],
+    queryFn: () => api.listServices(),
+    refetchInterval: 15000,
+  });
+
+  const redeployMutation = useMutation({
+    mutationFn: (svc: ServiceConfig) =>
+      api.deployService(svc.service_name, svc.environment, redeployTag ? { image_tag: redeployTag } : {}),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["services"] });
+      queryClient.invalidateQueries({ queryKey: ["deployments"] });
+      setRedeployTarget(null);
+      setRedeployTag("");
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (svc: ServiceConfig) => api.deleteService(svc.service_name, svc.environment),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["services"] });
+      setDeleteTarget(null);
+    },
+  });
+
+  const filtered = useMemo(() => {
+    if (!services) return [];
+    return services.filter((s) => {
+      const matchesEnv = envFilter === "all" || s.environment === envFilter;
+      const matchesSearch =
+        !search ||
+        s.service_name.toLowerCase().includes(search.toLowerCase()) ||
+        s.image_repository.toLowerCase().includes(search.toLowerCase());
+      return matchesEnv && matchesSearch;
+    });
+  }, [services, envFilter, search]);
+
+  const metrics = {
+    total: services?.length ?? 0,
+    running: services?.filter((s) => s.status === "running").length ?? 0,
+    failed: services?.filter((s) => s.status === "failed").length ?? 0,
+    deploying: services?.filter((s) => s.status === "deploying" || s.status === "pending").length ?? 0,
+  };
+
+  if (isLoading) return <Spinner.LogoPage label="Loading services..." />;
+
+  return (
+    <div className="space-y-6">
+      {/* Stats */}
+      <MetricsGrid>
+        <StatCard title="Total Services" value={metrics.total} icon={Box} />
+        <StatCard title="Running" value={metrics.running} icon={CheckCircle} variant="success" />
+        <StatCard title="Failed" value={metrics.failed} icon={XCircle} variant="danger" />
+        <StatCard title="Deploying" value={metrics.deploying} icon={Clock} variant="warning" />
+      </MetricsGrid>
+
+      {/* Filters */}
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1 max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Search services..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full pl-9 pr-3 py-2 text-sm bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-900 dark:text-white placeholder-gray-400 focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+          />
+        </div>
+        <div className="flex gap-1 rounded-lg border border-gray-200 dark:border-gray-700 p-0.5 bg-gray-50 dark:bg-gray-800/50">
+          {(["all", "dev", "staging", "prod"] as const).map((env) => (
+            <button
+              key={env}
+              onClick={() => setEnvFilter(env)}
+              className={cn(
+                "px-3 py-1.5 text-xs font-medium rounded-md transition-colors",
+                envFilter === env
+                  ? "bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm"
+                  : "text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              )}
+            >
+              {env === "all" ? "All" : env}
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={() => queryClient.invalidateQueries({ queryKey: ["services"] })}
+          className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+        >
+          <RefreshCw className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Table */}
+      {filtered.length === 0 ? (
+        <EmptyState
+          icon={Box}
+          title="No services found"
+          description='Deploy a service with the CLI: infrapilot deploy <name> --image <image>'
+        />
+      ) : (
+        <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-800/50">
+                <th className="text-left px-4 py-3 font-medium text-gray-500 dark:text-gray-400 uppercase text-xs tracking-wider">Service</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500 dark:text-gray-400 uppercase text-xs tracking-wider">Env</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500 dark:text-gray-400 uppercase text-xs tracking-wider">Image</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500 dark:text-gray-400 uppercase text-xs tracking-wider">Status</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500 dark:text-gray-400 uppercase text-xs tracking-wider">Deployed</th>
+                <th className="text-left px-4 py-3 font-medium text-gray-500 dark:text-gray-400 uppercase text-xs tracking-wider">Container</th>
+                <th className="px-4 py-3 w-10" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+              {filtered.map((svc) => {
+                const key = `${svc.service_name}:${svc.environment}`;
+                const displayTag = svc.current_tag ?? svc.image_tag;
+                return (
+                  <tr key={svc.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/40 transition-colors">
+                    <td className="px-4 py-3">
+                      <div className="font-medium text-gray-900 dark:text-white">{svc.service_name}</div>
+                      {svc.git_repo && (
+                        <div className="flex items-center gap-1 mt-0.5 text-xs text-gray-400">
+                          <GitBranch className="h-3 w-3" />
+                          {svc.git_repo}
+                        </div>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={cn(
+                        "inline-flex items-center px-2 py-0.5 rounded text-xs font-medium",
+                        svc.environment === "prod"
+                          ? "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+                          : svc.environment === "staging"
+                          ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400"
+                          : "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                      )}>
+                        {svc.environment}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="font-mono text-xs text-gray-700 dark:text-gray-300 flex items-center gap-1">
+                        <Tag className="h-3 w-3 text-gray-400 shrink-0" />
+                        <span className="truncate max-w-[220px]" title={`${svc.image_repository}:${displayTag}`}>
+                          {svc.image_repository}:{displayTag}
+                        </span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">{statusBadge(svc.status)}</td>
+                    <td className="px-4 py-3 text-gray-500 dark:text-gray-400 text-xs">
+                      {relativeTime(svc.deployed_at)}
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs text-gray-500 dark:text-gray-400">
+                      {svc.container_name ?? "—"}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="relative">
+                        <button
+                          onClick={() => setOpenMenu(openMenu === key ? null : key)}
+                          className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                        >
+                          <MoreHorizontal className="h-4 w-4" />
+                        </button>
+                        {openMenu === key && (
+                          <>
+                            <div className="fixed inset-0 z-10" onClick={() => setOpenMenu(null)} />
+                            <div className="absolute right-0 top-full mt-1 w-40 bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 shadow-lg z-20 py-1">
+                              <button
+                                onClick={() => { setRedeployTarget(svc); setRedeployTag(svc.current_tag ?? svc.image_tag ?? ""); setOpenMenu(null); }}
+                                className="flex items-center gap-2 w-full px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                              >
+                                <Rocket className="h-4 w-4 text-primary-500" />
+                                Redeploy
+                              </button>
+                              <button
+                                onClick={() => { setDeleteTarget(svc); setOpenMenu(null); }}
+                                className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                                Delete
+                              </button>
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Redeploy Modal */}
+      {redeployTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/50" onClick={() => { setRedeployTarget(null); setRedeployTag(""); }} />
+          <div className="relative bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-md mx-4 p-6">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="p-2 bg-primary-100 dark:bg-primary-900/30 rounded-lg">
+                <Rocket className="h-5 w-5 text-primary-600 dark:text-primary-400" />
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Redeploy Service</h3>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  {redeployTarget.service_name} · {redeployTarget.environment}
+                </p>
+              </div>
+            </div>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Image Tag
+                </label>
+                <input
+                  type="text"
+                  value={redeployTag}
+                  onChange={(e) => setRedeployTag(e.target.value)}
+                  placeholder={redeployTarget.image_tag || "latest"}
+                  className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg text-sm font-mono text-gray-900 dark:text-white placeholder-gray-400 focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                />
+                <p className="text-xs text-gray-400 mt-1">Leave blank to use the currently configured tag</p>
+              </div>
+              {redeployMutation.isError && (
+                <p className="text-sm text-red-600 dark:text-red-400">
+                  {(redeployMutation.error as Error)?.message ?? "Deploy failed"}
+                </p>
+              )}
+            </div>
+            <div className="flex justify-end gap-3 mt-6">
+              <button
+                onClick={() => { setRedeployTarget(null); setRedeployTag(""); redeployMutation.reset(); }}
+                className="px-4 py-2 text-sm bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg font-medium"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => redeployMutation.mutate(redeployTarget)}
+                disabled={redeployMutation.isPending}
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm bg-primary-600 hover:bg-primary-700 text-white rounded-lg font-medium disabled:opacity-50"
+              >
+                {redeployMutation.isPending ? (
+                  <><RefreshCw className="h-4 w-4 animate-spin" />Deploying...</>
+                ) : (
+                  <><Rocket className="h-4 w-4" />Deploy</>
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation Modal */}
+      {deleteTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/50" onClick={() => setDeleteTarget(null)} />
+          <div className="relative bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-sm mx-4 p-6">
+            <div className="flex items-center gap-3 mb-3">
+              <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-lg">
+                <Trash2 className="h-5 w-5 text-red-600 dark:text-red-400" />
+              </div>
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Delete Service</h3>
+            </div>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">
+              Remove <strong className="text-gray-900 dark:text-white">{deleteTarget.service_name}</strong> ({deleteTarget.environment}) from the service registry?
+            </p>
+            <p className="text-xs text-gray-400 mb-5">
+              This removes the service definition. Running containers are not stopped.
+            </p>
+            {deleteMutation.isError && (
+              <p className="text-sm text-red-600 dark:text-red-400 mb-3">
+                {(deleteMutation.error as Error)?.message ?? "Delete failed"}
+              </p>
+            )}
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={() => { setDeleteTarget(null); deleteMutation.reset(); }}
+                className="px-4 py-2 text-sm bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg font-medium"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => deleteMutation.mutate(deleteTarget)}
+                disabled={deleteMutation.isPending}
+                className="px-4 py-2 text-sm bg-red-600 hover:bg-red-700 text-white rounded-lg font-medium disabled:opacity-50"
+              >
+                {deleteMutation.isPending ? "Deleting..." : "Delete"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -989,6 +989,26 @@ export interface UpdatePolicyRequest {
 }
 
 // Deployments & Security Scanning
+export interface ServiceConfig {
+  id: string;
+  org_id: string;
+  agent_id: string;
+  service_name: string;
+  environment: string;
+  image_repository: string;
+  image_tag: string;
+  git_repo?: string;
+  webhook_id?: string;
+  created_at: string;
+  updated_at: string;
+  // Runtime info joined from latest deployment
+  status?: string;
+  current_tag?: string;
+  deployed_at?: string;
+  container_name?: string;
+  container_id?: string;
+}
+
 export interface Deployment {
   id: string;
   org_id: string;
@@ -4590,7 +4610,14 @@ export const api = {
     }),
 
   // Services view (cross-agent)
-  listServices: () => fetchAPI<Array<{ service_name: string; environment: string; agent_count: number }>>("/services"),
+  listServices: () => fetchAPI<ServiceConfig[]>("/services"),
+  deployService: (name: string, env: string, body: { image_tag?: string } = {}) =>
+    fetchAPI<{ deployment_id: string; service: string; environment: string; image: string; message: string }>(
+      `/services/${encodeURIComponent(name)}/deploy?env=${env}`,
+      { method: "POST", body: JSON.stringify(body) }
+    ),
+  deleteService: (name: string, env: string) =>
+    fetchAPI<{ message: string }>(`/services/${encodeURIComponent(name)}?env=${env}`, { method: "DELETE" }),
 
   listServiceDeployments: (serviceName: string) =>
     fetchAPI<Deployment[]>(`/services/${serviceName}/deployments`),


### PR DESCRIPTION
- Add /docker/services page: list all service_configs with status, per-row Redeploy (with tag input) and Delete actions, stat cards, search and env filter
- Add Services tab to docker Management nav group with Deploy Service action button
- Add Deploy button to registry Browse Images tag rows: opens modal to set service name + environment, calls deployService API
- Fix webhook deployments: load container_config from service_configs when available instead of always passing nil
- Add ServiceConfig type and deployService/deleteService API methods to frontend api.ts