### PR TITLE
docs: README — link guides, document ENCRYPTION_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go-1.24+-00ADD8?logo=go" alt="Go Version"></a>
   <a href="https://nextjs.org/"><img src="https://img.shields.io/badge/Next.js-15-000000?logo=next.js" alt="Next.js"></a>
   <a href="https://github.com/infrapilothq/InfraPilot/releases"><img src="https://img.shields.io/github/v/release/infrapilothq/InfraPilot?label=release" alt="Latest Release"></a>
+  <a href="https://infrapilot.org"><img src="https://img.shields.io/badge/Website-infrapilot.org-2ea44f" alt="Website"></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ docker compose -f docker-compose.prod.yml up -d
 | Variable | Required | Description |
 |----------|:--------:|-------------|
 | `JWT_SECRET` | ✅ | Secret for signing JWT tokens — generate with `openssl rand -base64 32` |
+| `ENCRYPTION_KEY` | | Enables credential encryption (AES-256-GCM) and webhook signature verification — 64-char hex, generate with `openssl rand -hex 32`. These features are disabled if unset |
 | `DATABASE_URL` | | PostgreSQL connection string (embedded if not set) |
 | `REDIS_URL` | | Redis connection string (embedded if not set) |
 | `POSTGRES_PASSWORD` | ✅ (prod) | PostgreSQL password |
@@ -254,6 +255,12 @@ docker compose -f docker-compose.dev.yml up --build
 ```
 
 Services start with hot reload: backend and agent use [Air](https://github.com/air-verse/air), frontend uses the Next.js dev server.
+
+
+## Documentation
+
+- [Architecture](docs/ARCHITECTURE.md) — components, gRPC data flow, and the agent model
+- [Deployment](docs/DEPLOYMENT.md) — production deployment and image publishing
 
 
 ## Contributing


### PR DESCRIPTION
Fills missing README info:

- **Documentation** section linking `docs/ARCHITECTURE.md` and `docs/DEPLOYMENT.md` (previously unlinked from the README).
- Documents the **`ENCRYPTION_KEY`** env var (AES-256-GCM credential encryption + webhook signature verification; disabled if unset).

Note: `docs/CI-CD.md` was intentionally not linked — it still references `.github/workflows/`, which has been removed, so it's stale.